### PR TITLE
docs: fix typo

### DIFF
--- a/transfer/transfer-06-consumer-pull-http/README.md
+++ b/transfer/transfer-06-consumer-pull-http/README.md
@@ -138,7 +138,7 @@ curl -H 'Content-Type: application/json' \
              "https://w3id.org/edc/v0.0.1/ns/publicApiUrl": "http://localhost:19291/public/"
            }
          }' \
-     -X POST "http://localhost:19193/management/v2/dataplanes" | -s | jq
+     -X POST "http://localhost:19193/management/v2/dataplanes" -s | jq
 ```
 
 ### 2. Register data plane instance for consumer


### PR DESCRIPTION
## What this PR changes/adds

It fixes the typo such that the curl command works again.

## Why it does that

The -s should be the silent option of the curl command and not piped.

## Further notes

btw this link in the Contributing.md is broken: https://github.com/eclipse-edc/docs/blob/e7730f432305775542503e4ecb61aa7e829bea30/CONTRIBUTING.md?plain=1#L132

## Linked Issue(s)

none
